### PR TITLE
allowing tags with more than 32 chars in rfc3164

### DIFF
--- a/README
+++ b/README
@@ -50,6 +50,8 @@ You should see
     facility  : 4
     severity  : 2
 
+> To avoid the limit of 32 chars in the tag, use `p.SetStrict(false)`
+
 Parsing an RFC 5424 syslog message
 ----------------------------------
 

--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -18,6 +18,7 @@ type Parser struct {
 	version  int
 	header   header
 	message  rfc3164message
+	strict   bool
 }
 
 type header struct {
@@ -35,7 +36,12 @@ func NewParser(buff []byte) *Parser {
 		buff:   buff,
 		cursor: 0,
 		l:      len(buff),
+		strict: true,
 	}
+}
+
+func (p *Parser) SetStrict(strict bool) {
+	p.strict = strict
 }
 
 func (p *Parser) Parse() error {
@@ -194,7 +200,7 @@ func (p *Parser) parseTag() (string, error) {
 		endOfTag = (b == ':' || b == ' ')
 		tooLong = (p.cursor > maxLen)
 
-		if tooLong {
+		if p.strict && tooLong {
 			return "", ErrTagTooLong
 		}
 


### PR DESCRIPTION
Hi, 

First at all, congratulations for this excellent syslog parser.

I am implementing a small library for make a [syslog server](https://github.com/mcuadros/go-syslog) as dependency for another project.

I detected that all syslog servers (osx syslogd) not follow the limitation of length in the tag, so i decided to send this pr to enable a way to remove this limitation on-demand. 

If you dont like it my implementation just tell me and i will change it.

Regards and thanks

```
<31>Dec 26 05:08:46 mcuadros-air com.apple.metadata.mdflagwriter[296]: Handle message /Users/mcuadros/Library/Application Support/Sublime Text 3/Local/Auto Save Session.sublime_session
```
