### PR TITLE
Update rfc3164 to accept custom timestamp formats.

### DIFF
--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Parser struct {
+	tsFmts   []string
 	buff     []byte
 	cursor   int
 	l        int
@@ -15,6 +16,13 @@ type Parser struct {
 	header   header
 	message  rfc3164message
 }
+
+var (
+	DefaultTimestampFormats = []string{
+		"Jan 02 15:04:05",
+		"Jan  2 15:04:05",
+	}
+)
 
 type header struct {
 	timestamp time.Time
@@ -27,7 +35,12 @@ type rfc3164message struct {
 }
 
 func NewParser(buff []byte) *Parser {
+	return NewParserWithTimestampFormats(buff, DefaultTimestampFormats)
+}
+
+func NewParserWithTimestampFormats(buff []byte, tsFmts []string) *Parser {
 	return &Parser{
+		tsFmts: tsFmts,
 		buff:   buff,
 		cursor: 0,
 		l:      len(buff),
@@ -123,13 +136,8 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
 	var tsFmtLen int
 	var sub []byte
 
-	tsFmts := []string{
-		"Jan 02 15:04:05",
-		"Jan  2 15:04:05",
-	}
-
 	found := false
-	for _, tsFmt := range tsFmts {
+	for _, tsFmt := range p.tsFmts {
 		tsFmtLen = len(tsFmt)
 
 		if p.cursor+tsFmtLen > p.l {

--- a/rfc3164/rfc3164_test.go
+++ b/rfc3164/rfc3164_test.go
@@ -27,6 +27,7 @@ func (s *Rfc3164TestSuite) TestParser_Valid(c *C) {
 
 	p := NewParser(buff)
 	expectedP := &Parser{
+		tsFmts: DefaultTimestampFormats,
 		buff:   buff,
 		cursor: 0,
 		l:      len(buff),
@@ -120,6 +121,14 @@ func (s *Rfc3164TestSuite) TestParseTimestamp_Valid(c *C) {
 	ts := time.Date(now.Year(), time.October, 11, 22, 14, 15, 0, time.UTC)
 
 	s.assertTimestamp(c, ts, buff, len(buff), nil)
+}
+
+func (s *Rfc3164TestSuite) TestParseTimestamp_ValidCustomFormat(c *C) {
+	buff := []byte("2014-10-11T22:14:15Z")
+	ts := time.Date(2014, time.October, 11, 22, 14, 15, 0, time.UTC)
+	tsFmts := []string{"2006-01-02T15:04:05Z"}
+
+	s.assertTimestampWithFormat(c, ts, buff, tsFmts, len(buff), nil)
 }
 
 func (s *Rfc3164TestSuite) TestParseTag_Pid(c *C) {
@@ -230,7 +239,11 @@ func (s *Rfc3164TestSuite) BenchmarkParsemessage(c *C) {
 }
 
 func (s *Rfc3164TestSuite) assertTimestamp(c *C, ts time.Time, b []byte, expC int, e error) {
-	p := NewParser(b)
+	s.assertTimestampWithFormat(c, ts, b, DefaultTimestampFormats, expC, e)
+}
+
+func (s *Rfc3164TestSuite) assertTimestampWithFormat(c *C, ts time.Time, b []byte, expFmt []string, expC int, e error) {
+	p := NewParserWithTimestampFormats(b, expFmt)
 	obtained, err := p.parseTimestamp()
 	c.Assert(obtained, Equals, ts)
 	c.Assert(p.cursor, Equals, expC)


### PR DESCRIPTION
This is in violation of the RFC itself, but allows
syslogparser to parse output from Golang’s own
log/syslog package.
