### PR TITLE
Handle not finding a tag in message

### DIFF
--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -189,6 +189,12 @@ func (p *Parser) parseTag() (string, error) {
 	from := p.cursor
 
 	for {
+		if p.cursor == p.l {
+			// no tag found, reset cursor for content
+			p.cursor = from
+			return "", nil
+		}
+
 		b = p.buff[p.cursor]
 		bracketOpen = (b == '[')
 		endOfTag = (b == ':' || b == ' ')


### PR DESCRIPTION
If a tag is not found in `parseTag()`, reset the cursor for content parsing and return an empty string for the tag.

Fixes #9.