### PR TITLE
Support for rfc3164 variants which lack the host name

### DIFF
--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -15,6 +15,7 @@ type Parser struct {
 	header   header
 	message  rfc3164message
 	location *time.Location
+	hostname string
 }
 
 type header struct {
@@ -40,6 +41,10 @@ func (p *Parser) Location(location *time.Location) {
 	p.location = location
 }
 
+func (p *Parser) Hostname(hostname string) {
+	p.hostname = hostname
+}
+
 func (p *Parser) Parse() error {
 	pri, err := p.parsePriority()
 	if err != nil {
@@ -51,7 +56,9 @@ func (p *Parser) Parse() error {
 		return err
 	}
 
-	p.cursor++
+	if p.buff[p.cursor] == ' ' {
+		p.cursor++
+	}
 
 	msg, err := p.parsemessage()
 	if err != syslogparser.ErrEOL {
@@ -174,7 +181,11 @@ func (p *Parser) parseTimestamp() (time.Time, error) {
 }
 
 func (p *Parser) parseHostname() (string, error) {
-	return syslogparser.ParseHostname(p.buff, &p.cursor, p.l)
+	if p.hostname != "" {
+		return p.hostname, nil
+	} else {
+		return syslogparser.ParseHostname(p.buff, &p.cursor, p.l)
+	}
 }
 
 // http://tools.ietf.org/html/rfc3164#section-4.1.3

--- a/rfc3164/rfc3164_test.go
+++ b/rfc3164/rfc3164_test.go
@@ -54,6 +54,31 @@ func (s *Rfc3164TestSuite) TestParser_Valid(c *C) {
 	c.Assert(obtained, DeepEquals, expected)
 }
 
+func (s *Rfc3164TestSuite) TestParseWithout_Hostname(c *C) {
+	buff := []byte("<30>Jun 23 13:17:42 chronyd[1119]: Selected source 192.168.65.1")
+
+	p := NewParser(buff)
+	p.Hostname("testhost")
+
+	err := p.Parse()
+	c.Assert(err, IsNil)
+
+	now := time.Now()
+
+	obtained := p.Dump()
+	expected := syslogparser.LogParts{
+		"timestamp": time.Date(now.Year(), time.June, 23, 13, 17, 42, 0, time.UTC),
+		"hostname":  "testhost",
+		"tag":       "chronyd",
+		"content":   "Selected source 192.168.65.1",
+		"priority":  30,
+		"facility":  3,
+		"severity":  6,
+	}
+
+	c.Assert(obtained, DeepEquals, expected)
+}
+
 func (s *Rfc3164TestSuite) TestParseHeader_Valid(c *C) {
 	buff := []byte("Oct 11 22:14:15 mymachine ")
 	now := time.Now()

--- a/rfc3164/rfc3164_test.go
+++ b/rfc3164/rfc3164_test.go
@@ -27,9 +27,10 @@ func (s *Rfc3164TestSuite) TestParser_Valid(c *C) {
 
 	p := NewParser(buff)
 	expectedP := &Parser{
-		buff:   buff,
-		cursor: 0,
-		l:      len(buff),
+		buff:     buff,
+		cursor:   0,
+		l:        len(buff),
+		location: time.UTC,
 	}
 
 	c.Assert(p, DeepEquals, expectedP)


### PR DESCRIPTION
The busybox syslogd produces syslog messages like this:
```
<30>Jun 23 13:17:42 chronyd[1119]: Selected source 192.168.65.1
```
because it [forwards the `/dev/log` datagram as is](https://git.busybox.net/busybox/tree/sysklogd/syslogd.c#n1054) and this does not include the hostname field.

To support this case I have added a method to set the hostname the parser should use which can then be called before parsing. The idea being that the caller can know something like this by looking at the incoming network connection (and perhaps doing a reverse DNS lookup). I think this is what the comment in the busybox code is sort of implying (i.e. the hostname could be a lie, so the receiver should probably make up their own mind)

Perhaps this really ought to be a new (`rfc3164busybox`? `rfc3164devlog`?) package, but that seems like an awful lot of code duplication for such a simple change.

The first patch fixes up the test suite, I also added a new test case to cover the new behaviour. Everything passes for me.