### PR TITLE
add length check in parseTag()'s loop

### DIFF
--- a/rfc3164/rfc3164.go
+++ b/rfc3164/rfc3164.go
@@ -200,6 +200,9 @@ func (p *Parser) parseTag() (string, error) {
 	from := p.cursor
 
 	for {
+		if p.l <= p.cursor {
+			break
+		}
 		b = p.buff[p.cursor]
 		bracketOpen = (b == '[')
 		endOfTag = (b == ':' || b == ' ')


### PR DESCRIPTION
avoid out of index error